### PR TITLE
Porting features from v1.12 to v2.1

### DIFF
--- a/docs/how-to/how-to-use-virtio-fs-with-kata.md
+++ b/docs/how-to/how-to-use-virtio-fs-with-kata.md
@@ -9,4 +9,4 @@ Container deployments utilize explicit or implicit file sharing between host fil
 
 As of the 2.0 release of Kata Containers, [virtio-fs](https://virtio-fs.gitlab.io/) is the default filesystem sharing mechanism.
 
-virtio-fs support works out of the box for `cloud-hypervisor` and `qemu`, when Kata Containers is deployed using `kata-deploy`. Learn more about `kata-deploy` and how to use `kata-deploy` in Kubernetes [here](https://github.com/kata-containers/packaging/tree/master/kata-deploy#kubernetes-quick-start).
+virtio-fs support works out of the box for `cloud-hypervisor` and `qemu`, when Kata Containers is deployed using `kata-deploy`. Learn more about `kata-deploy` and how to use `kata-deploy` in Kubernetes [here](https://github.com/kata-containers/kata-containers/tree/main/tools/packaging/kata-deploy#kubernetes-quick-start).

--- a/src/runtime/virtcontainers/kata_agent.go
+++ b/src/runtime/virtcontainers/kata_agent.go
@@ -71,7 +71,7 @@ var (
 	errorMissingOCISpec         = errors.New("Missing OCI specification")
 	defaultKataHostSharedDir    = "/run/kata-containers/shared/sandboxes/"
 	defaultKataGuestSharedDir   = "/run/kata-containers/shared/containers/"
-	mountGuestTag               = "kataShared"
+	mountGuestTag               = "ecrShared"
 	defaultKataGuestSandboxDir  = "/run/kata-containers/sandbox/"
 	type9pFs                    = "9p"
 	typeVirtioFS                = "virtiofs"


### PR DESCRIPTION
涉及需求：
- [支持 qcow2 镜像创建虚拟机](https://github.com/easystack/runtime/commit/b774d374d88fd9405c8bc068bb32c09d849f2acc)
- [kata_agent: change mountGuestTag](https://github.com/easystack/runtime/pull/5)
- [Provide information to agent to let it safely wait for VFIO devices to complete hotplug](https://github.com/easystack/runtime/pull/4)
- [Update cgroup to increase memory limits value](https://github.com/easystack/runtime/pull/7)
- [Each sandbox uses a separate copy of AAVMF_VARS.fd (aarch64)](https://github.com/easystack/runtime/pull/9)
- [build ecr-deploy image](https://github.com/easystack/runtime/pull/8)
- [setup stop_ecr service on host](https://github.com/easystack/runtime/pull/11)
- [shimv2: return the hypervisor's pid as the container pid](https://github.com/easystack/runtime/pull/12)
- [stop_ecr service order](https://github.com/easystack/runtime/pull/14)

跟踪 Jira: EAS-75557